### PR TITLE
🐛 Fix: 회원가입 필드명 변경, 성향페이지 닉네임 출력 문제 수정

### DIFF
--- a/src/pages/signup/signup.js
+++ b/src/pages/signup/signup.js
@@ -118,6 +118,9 @@ const SignUp = () => {
                 const result = await response.json();
     
                 if (response.ok) {
+                     // 회원가입 성공 시 토큰을 localStorage에 저장
+                    const token = result.data.token;
+                    localStorage.setItem('authToken', token); // 로컬스토리지에 토큰 저장
                     navigate('/question');
                 } else {
                     console.error('회원가입 실패:', result.message);

--- a/src/pages/signup/signup.js
+++ b/src/pages/signup/signup.js
@@ -14,7 +14,7 @@ const SignUp = () => {
         user_pwd: '',
         confirmPassword: '',
         user_email: '',
-        phone: '',
+        user_phone: '',
         user_birthday: '',
         user_gender: '',
     });
@@ -67,6 +67,9 @@ const SignUp = () => {
         if (!formData.confirmPassword) newErrors.confirmPassword = '비밀번호 확인을 입력해주세요.';
         if (!formData.user_email) newErrors.user_email = '이메일을 입력해주세요.';
         if (!formData.user_birthday) newErrors.user_birthday = '생일을 입력해주세요.';
+        if (!formData.user_phone) newErrors.user_phone = '전화번호를 입력해주세요.';
+    if (!formData.user_gender) newErrors.user_gender = '성별을 선택해주세요.';
+
     
         if (formData.user_pwd && !/^(?=.*[!@#$%^&*])[A-Za-z\d!@#$%^&*]{6,15}$/.test(formData.user_pwd)) {
             newErrors.user_pwd = '특수문자를 포함한 6~15자로 입력해주시기 바랍니다.';
@@ -95,8 +98,9 @@ const SignUp = () => {
                 user_nick: formData.user_nick,
                 sign_id: formData.sign_id,
                 user_pwd: formData.user_pwd,
+                confirmPassword: formData.confirmPassword,
                 user_email: formData.user_email,
-                phone: formData.phone,
+                user_phone: formData.user_phone,
                 user_birthday: formData.user_birthday,
                 user_gender: formData.user_gender,
                 verificationCode: verificationCode.join('') // 인증번호 추가
@@ -335,12 +339,12 @@ const SignUp = () => {
                     </div>
 
                     <div className="SignUp-page__input-group">
-                        <label htmlFor="phone" className="SignUp-page__label">전화번호</label>
+                        <label htmlFor="user_phone" className="SignUp-page__label">전화번호</label>
                         <input
                             type="tel"
-                            id="phone"
-                            name="phone"
-                            value={formData.phone}
+                            id="user_phone"
+                            name="user_phone"
+                            value={formData.user_phone}
                             onChange={handleInputChange}
                             className="SignUp-page__input"
                             placeholder="010-XXXX-XXXX"

--- a/src/pages/tendency/city_tendency.js
+++ b/src/pages/tendency/city_tendency.js
@@ -14,7 +14,7 @@ function CityTendency() {
     // 사용자 정보를 가져오는 API 호출
     const fetchUserData = async () => {
       try {
-        const token = localStorage.getItem('authToken'); // 로컬스토리지에서 토큰 가져오기
+        const token = localStorage.getItem('token'); // 로컬스토리지에서 토큰 가져오기
         if (!token) {
           throw new Error('No token found');
         }

--- a/src/pages/tendency/city_tendency.js
+++ b/src/pages/tendency/city_tendency.js
@@ -14,19 +14,32 @@ function CityTendency() {
     // 사용자 정보를 가져오는 API 호출
     const fetchUserData = async () => {
       try {
-        const response = await fetch('http://localhost:3001/users/me'); // 사용자 정보 API 호출
+        const token = localStorage.getItem('authToken'); // 로컬스토리지에서 토큰 가져오기
+        if (!token) {
+          throw new Error('No token found');
+        }
+  
+        const response = await fetch('http://localhost:3001/users/me', {
+          headers: {
+            'Authorization': `Bearer ${token}`,
+          },
+        });
+  
         if (!response.ok) {
           throw new Error('서버에 오류가 발생했습니다.');
         }
+  
         const data = await response.json();
-        setUserNick(data.user_nick); // userNick 상태 업데이트
+        setUserNick(data.data.user_nick); // 서버에서 응답받은 데이터를 사용
+        console.log('Fetched userNick:', data.data.user_nick); // 닉네임 콘솔 출력
       } catch (error) {
         console.error('Error fetching user data:', error);
       }
     };
-
+  
     fetchUserData(); // 컴포넌트 마운트 시 사용자 정보 가져오기
   }, []);
+  
 
   const handleSubmit = async () => {
     const userId = localStorage.getItem('userId');

--- a/src/pages/tendency/forest_tendency.js
+++ b/src/pages/tendency/forest_tendency.js
@@ -9,37 +9,42 @@ import MincityImage from '../../assets/images/mincity.png';
 function ForestTendency() {
   const navigate = useNavigate();
   const [userNick, setUserNick] = useState(''); // userNick 상태 추가
+  const [error, setError] = useState(null); // 에러 상태 추가
 
   useEffect(() => {
     // 사용자 정보를 가져오는 API 호출
     const fetchUserData = async () => {
       try {
-          const token = localStorage.getItem('authToken'); // 로컬스토리지에서 토큰 가져오기
-          if (!token) {
-              throw new Error('No token found');
-          }
+        const token = localStorage.getItem('token'); // 로컬스토리지에서 토큰 가져오기
+        if (!token) {
+          throw new Error('No token found');
+        }
 
-          const response = await fetch('http://localhost:3001/users/me', {
-              headers: {
-                  'Authorization': `Bearer ${token}`,
-              },
-          });
+        const response = await fetch('http://localhost:3001/users/me', {
+          headers: {
+            'Authorization': `Bearer ${token}`,
+          },
+        });
 
-          if (!response.ok) {
-              throw new Error('서버에 오류가 발생했습니다.');
-          }
+        if (!response.ok) {
+          throw new Error('서버에 오류가 발생했습니다.');
+        }
 
-          const data = await response.json();
-          setUserNick(data.data.user_nick); // 서버에서 응답받은 데이터를 사용
-          console.log('Fetched userNick:', data.data.user_nick); // 닉네임 콘솔 출력
+        const data = await response.json();
+        setUserNick(data.data.user_nick); // 서버에서 응답받은 데이터를 사용
       } catch (error) {
-          console.error('Error fetching user data:', error);
+        setError('사용자 정보를 불러오는 중 오류가 발생했습니다.');
+        console.error('Error fetching user data:', error);
       }
-  };
+    };
 
-  fetchUserData(); // 컴포넌트 마운트 시 사용자 정보 가져오기
-}, []);
-  
+    fetchUserData(); // 컴포넌트 마운트 시 사용자 정보 가져오기
+  }, []);
+
+  if (error) {
+    return <div>{error}</div>;
+  }
+
   return (
     <div className="Tendency">
       <GuidePopup />
@@ -50,13 +55,21 @@ function ForestTendency() {
             <div className="forest_tendency_info-content">
               <div className="forest_tendency_info-header">
                 {/* 닉네임만 출력하는 부분 */}
-                <h1>{userNick}님은 숲 성향이에요</h1> {/* userNick 상태를 사용하여 닉네임 표시 */}
+                <h1>{userNick ? `${userNick}님은 숲 성향이에요` : '성향을 불러오는 중...'}</h1> {/* 닉네임 표시 */}
               </div>
               <div className="forest_tendency_info-section">
                 <h2>숲이란?</h2>
                 <div className="forest_tendency_text-container">
                   <p>
                     숲은 여유롭게 하루를 보내는 사람들을 위한 기록장입니다. 하루를 천천히 흘려보내며 작은 것에서 큰 의미를 찾아내는 무너에게 최적의 공간입니다. 느리게 가는 만큼 세상을 더 깊이 바라보고 느끼는 여유로움을 통해, 하루의 가치를 새롭게 발견할 수 있을 거예요. 비슷한 무너들과 함께 어우러지는 숲속을 usdiary가 만들어드립니다. 숲에서 마음을 가꾸고, 하루를 차분히 정리해보세요.
+                  </p>
+                </div>
+              </div>
+              <div className="forest_tendency_info-section">
+                <h2>숲에는 이런 기능이 있어요</h2>
+                <div className="forest_tendency_text-container">
+                  <p>
+                    usdiary에서는 하루를 간단하고 즐겁게 기록할 수 있는 '오늘의 질문'이 제공됩니다. 일상적인 질문부터 깊이 있는 질문까지 다양한 주제로 하루를 색다르게 돌아보며 기록하는 시간을 가질 수 있습니다. 그날의 느낌과 생각을 자연스럽게 풀어내며, 일상에 새로운 시선을 더해보세요.
                   </p>
                 </div>
               </div>

--- a/src/pages/tendency/forest_tendency.js
+++ b/src/pages/tendency/forest_tendency.js
@@ -14,92 +14,63 @@ function ForestTendency() {
     // 사용자 정보를 가져오는 API 호출
     const fetchUserData = async () => {
       try {
-        const response = await fetch('http://localhost:3001/users/me'); // 사용자 정보 API 호출
-        if (!response.ok) {
-          throw new Error('서버에 오류가 발생했습니다.');
-        }
-        const data = await response.json();
-        setUserNick(data.user_nick); // userNick 상태 업데이트
+          const token = localStorage.getItem('authToken'); // 로컬스토리지에서 토큰 가져오기
+          if (!token) {
+              throw new Error('No token found');
+          }
+
+          const response = await fetch('http://localhost:3001/users/me', {
+              headers: {
+                  'Authorization': `Bearer ${token}`,
+              },
+          });
+
+          if (!response.ok) {
+              throw new Error('서버에 오류가 발생했습니다.');
+          }
+
+          const data = await response.json();
+          setUserNick(data.data.user_nick); // 서버에서 응답받은 데이터를 사용
+          console.log('Fetched userNick:', data.data.user_nick); // 닉네임 콘솔 출력
       } catch (error) {
-        console.error('Error fetching user data:', error);
+          console.error('Error fetching user data:', error);
       }
-    };
-
-    fetchUserData(); // 컴포넌트 마운트 시 사용자 정보 가져오기
-  }, []);
-
-  const handleSubmit = async () => {
-    const userId = localStorage.getItem('userId');
-    const token = localStorage.getItem('authToken');
-
-    if (!userId || !token) {
-      console.error('로그인 정보가 없습니다.');
-      return;
-    }
-
-    try {
-      const response = await fetch(`http://localhost:3001/users/${userId}/tendency`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`,
-        },
-        body: JSON.stringify({ selection: '숲' }), // 서버로 전송할 데이터 ('숲')
-      });
-
-      if (!response.ok) {
-        throw new Error('서버에 오류가 발생했습니다.');
-      }
-
-      const data = await response.json();
-      console.log('Server response:', data);
-    } catch (error) {
-      console.error('Error:', error);
-    }
   };
 
-  const handleCityTendencyClick = () => {
-    navigate('/city_tendency');
-  };
-
+  fetchUserData(); // 컴포넌트 마운트 시 사용자 정보 가져오기
+}, []);
+  
   return (
     <div className="Tendency">
-      <GuidePopup/>
-    <div className="Forest_Tendency">
-      <Menu />
-      <div className="forest_tendency">
-        <div className="forest_tendency_info-box">
-          <div className="forest_tendency_info-content">
-            <div className="forest_tendency_info-header">
-              <h1>{userNick}님은 숲 성향이에요</h1> {/* userNick 상태를 사용하여 닉네임 표시 */}
-            </div>
-            <div className="forest_tendency_info-section">
-              <h2>숲이란?</h2>
-              <div className="forest_tendency_text-container">
-                <p>
-                  숲은 여유롭게 하루를 보내는 사람들을 위한 기록장입니다. 하루를 천천히 흘려보내며 작은 것에서 큰 의미를 찾아내는 무너에게 최적의 공간입니다. 느리게 가는 만큼 세상을 더 깊이 바라보고 느끼는 여유로움을 통해, 하루의 가치를 새롭게 발견할 수 있을 거예요. 비슷한 무너들과 함께 어우러지는 숲속을 usdiary가 만들어드립니다. 숲에서 마음을 가꾸고, 하루를 차분히 정리해보세요.
-                </p>
+      <GuidePopup />
+      <div className="Forest_Tendency">
+        <Menu />
+        <div className="forest_tendency">
+          <div className="forest_tendency_info-box">
+            <div className="forest_tendency_info-content">
+              <div className="forest_tendency_info-header">
+                {/* 닉네임만 출력하는 부분 */}
+                <h1>{userNick}님은 숲 성향이에요</h1> {/* userNick 상태를 사용하여 닉네임 표시 */}
               </div>
-            </div>
-            <div className="forest_tendency_info-section">
-              <h2>숲에는 이런 기능이 있어요</h2>
-              <div className="forest_tendency_text-container">
-                <p>
-                  usdiary에서는 하루를 간단하고 즐겁게 기록할 수 있는 '오늘의 질문'이 제공됩니다. 일상적인 질문부터 깊이 있는 질문까지 다양한 주제로 하루를 색다르게 돌아보며 기록하는 시간을 가질 수 있습니다. 그날의 느낌과 생각을 자연스럽게 풀어내며, 일상에 새로운 시선을 더해보세요.
-                </p>
+              <div className="forest_tendency_info-section">
+                <h2>숲이란?</h2>
+                <div className="forest_tendency_text-container">
+                  <p>
+                    숲은 여유롭게 하루를 보내는 사람들을 위한 기록장입니다. 하루를 천천히 흘려보내며 작은 것에서 큰 의미를 찾아내는 무너에게 최적의 공간입니다. 느리게 가는 만큼 세상을 더 깊이 바라보고 느끼는 여유로움을 통해, 하루의 가치를 새롭게 발견할 수 있을 거예요. 비슷한 무너들과 함께 어우러지는 숲속을 usdiary가 만들어드립니다. 숲에서 마음을 가꾸고, 하루를 차분히 정리해보세요.
+                  </p>
+                </div>
               </div>
+              <button className="forest_tendency_submit-button">숲 성향으로 결정하기</button>
+              <p className="forest_tendency_note">* 일주일 동안 성향 변경이 가능합니다</p>
             </div>
-            <button className="forest_tendency_submit-button" onClick={handleSubmit}>숲 성향으로 결정하기</button>
-            <p className="forest_tendency_note">* 일주일 동안 성향 변경이 가능합니다</p>
+            <img src={BigtreeImage} alt="forest_tendency_Description" className="forest_tendency_info-image" />
+            <button className="forest_tendency_city-tendency-button" onClick={() => navigate('/city_tendency')}>
+              <img src={MincityImage} alt="forest_tendency_City Tendency" className="forest_tendency_city-image" />
+              도시 성향 보러가기
+            </button>
           </div>
-          <img src={BigtreeImage} alt="forest_tendency_Description" className="forest_tendency_info-image" />
-          <button className="forest_tendency_city-tendency-button" onClick={handleCityTendencyClick}>
-            <img src={MincityImage} alt="forest_tendency_City Tendency" className="forest_tendency_city-image" />
-            도시 성향 보러가기
-          </button>
         </div>
       </div>
-    </div>
     </div>
   );
 }

--- a/src/pages/tendency/question.js
+++ b/src/pages/tendency/question.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import '../../assets/css/questions.css';
 import Menu from '../../components/menu';
@@ -32,6 +32,19 @@ const Question = () => {
   const [forestCount, setForestCount] = useState(0);
   const [cityCount, setCityCount] = useState(0);
   const navigate = useNavigate();
+
+  // 쿼리 파라미터에서 JWT 토큰을 추출하여 로컬 스토리지에 저장하는 로직
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const token = params.get('token');
+
+    if (token) {
+      // 토큰을 로컬 스토리지에 저장
+      localStorage.setItem('token', token);
+      // 쿼리 파라미터를 제거한 후 질문 페이지로 리다이렉트
+      navigate('/question', { replace: true });
+    }
+  }, [navigate]);
 
   const handleAnswer = (answerIndex) => {
     setSelectedAnswers((prevSelected) => {

--- a/src/pages/tendency/question.js
+++ b/src/pages/tendency/question.js
@@ -31,7 +31,6 @@ const Question = () => {
   const [selectedAnswers, setSelectedAnswers] = useState([null, null]);
   const [forestCount, setForestCount] = useState(0);
   const [cityCount, setCityCount] = useState(0);
-  const [userNick, setUserNick] = useState(''); // 사용자 닉네임 상태 추가
   const navigate = useNavigate();
 
   // 쿼리 파라미터에서 JWT 토큰을 추출하여 로컬 스토리지에 저장하는 로직
@@ -82,8 +81,6 @@ const Question = () => {
       <Menu/>
       <div className="Question-container">
         <div className="Question-box">
-          {/* 사용자 닉네임 출력 */}
-          <h2>{userNick}님, 환영합니다!</h2>
           <div className="navigation">
             {currentQuestion > 0 && (
               <button className="nav-button" onClick={() => setCurrentQuestion(currentQuestion - 1)}>&lt;</button>

--- a/src/pages/tendency/question.js
+++ b/src/pages/tendency/question.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import '../../assets/css/questions.css';
 import Menu from '../../components/menu';
@@ -31,7 +31,50 @@ const Question = () => {
   const [selectedAnswers, setSelectedAnswers] = useState([null, null]);
   const [forestCount, setForestCount] = useState(0);
   const [cityCount, setCityCount] = useState(0);
+  const [userNick, setUserNick] = useState(''); // 사용자 닉네임 상태 추가
   const navigate = useNavigate();
+
+  // 쿼리 파라미터에서 JWT 토큰을 추출하여 로컬 스토리지에 저장하는 로직
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const token = params.get('token');
+
+    if (token) {
+      // 기존 로컬 스토리지의 정보 모두 삭제 (초기화)
+      localStorage.clear();
+
+      // 새로 받은 토큰 저장
+      localStorage.setItem('token', token);
+      
+      // 쿼리 파라미터를 제거한 후 질문 페이지로 리다이렉트
+      navigate('/question', { replace: true });
+    }
+  }, [navigate]);
+
+  // JWT 토큰을 통해 사용자 정보 조회
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+
+    if (token) {
+      // JWT 토큰으로 사용자 정보 요청
+      fetch('http://localhost:3001/users/me', {
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json'
+        }
+      })
+      .then(response => response.json())
+      .then(data => {
+        if (data.data) {
+          setUserNick(data.data.user_nick); // 사용자 닉네임 상태 업데이트
+        }
+      })
+      .catch(error => {
+        console.error('사용자 정보 조회 실패:', error);
+      });
+    }
+  }, []);
 
   const handleAnswer = (answerIndex) => {
     setSelectedAnswers((prevSelected) => {
@@ -67,29 +110,31 @@ const Question = () => {
     <div className='Question'>
       <Menu/>
       <div className="Question-container">
-      <div className="Question-box">
-        <div className="navigation">
-          {currentQuestion > 0 && (
-            <button className="nav-button" onClick={() => setCurrentQuestion(currentQuestion - 1)}>&lt;</button>
-          )}
-        </div>
-        <div className="question">{questions[currentQuestion].question}</div>
-        <div className="answers">
-          {questions[currentQuestion].answers.map((answer, index) => (
-            <button
-              key={index}
-              className={`answer-button ${selectedAnswers[currentQuestion] === index ? 'selected' : ''}`}
-              onClick={() => handleAnswer(index)}
-            >
-              {answer}
-            </button>
-          ))}
-        </div>
-        <div className="navigation">
-          <button className="nav-button" onClick={handleNext}>&gt;</button>
+        <div className="Question-box">
+          {/* 사용자 닉네임 출력 */}
+          <h2>{userNick}님, 환영합니다!</h2>
+          <div className="navigation">
+            {currentQuestion > 0 && (
+              <button className="nav-button" onClick={() => setCurrentQuestion(currentQuestion - 1)}>&lt;</button>
+            )}
+          </div>
+          <div className="question">{questions[currentQuestion].question}</div>
+          <div className="answers">
+            {questions[currentQuestion].answers.map((answer, index) => (
+              <button
+                key={index}
+                className={`answer-button ${selectedAnswers[currentQuestion] === index ? 'selected' : ''}`}
+                onClick={() => handleAnswer(index)}
+              >
+                {answer}
+              </button>
+            ))}
+          </div>
+          <div className="navigation">
+            <button className="nav-button" onClick={handleNext}>&gt;</button>
+          </div>
         </div>
       </div>
-    </div>
     </div>
   );
 };


### PR DESCRIPTION
[시영]
1. 회원가입 페이지에서 phone 필드를 user_phone으로 변경하여 create Account가 동작하도록 구현
2. 전화번호와 성별 필드도 추가
3. 회원가입 후 질문페이지를 완료하고 성향페이지를 렌더링했을 때 닉네임이 출력되지 않는 문제 해결

* 랜덤질문조회 api를 만들었으니 오늘의 질문에 뜨도록 수정 부탁드립니다(https://www.notion.so/9b4120a73eee4a2f8e2a1f1ef08ebbd9?pvs=4)
* 프로필 페이지의 비밀번호 확인 api도 구현 완료
(https://www.notion.so/b8184ce52c0545e3a5627e1389d4b1e9?pvs=4)
* 공지사항 api도 구현 완료 (목록조회, 단일조회, 등록, 수정, 삭제)
- 가능하면 공지사항 페이지 버튼을 notification이 아닌 **notice**로 수정부탁드립니다! ( 알림 기능이 notification으로)